### PR TITLE
feat: add query params to GetTransactions endpoint

### DIFF
--- a/buxclient_test.go
+++ b/buxclient_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/BuxOrg/go-buxclient/transports"
 	"github.com/bitcoinschema/go-bitcoin/v2"
 	"github.com/libsv/go-bt/v2"
+	"github.com/mrz1836/go-datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -240,7 +241,7 @@ func TestDraftTransaction(t *testing.T) {
 
 	for _, transportHandler := range transportHandlers {
 		t.Run("draft transaction "+transportHandler.Type, func(t *testing.T) {
-			var client = getTestBuxClient(transportHandler, false)
+			client := getTestBuxClient(transportHandler, false)
 			config := &bux.TransactionConfig{
 				Outputs: []*bux.TransactionOutput{{
 					Satoshis: 1000,
@@ -428,7 +429,7 @@ func TestGetTransactions(t *testing.T) {
 			metadata := &bux.Metadata{
 				"run_id": "3108aa426fc7102488bb0ffd",
 			}
-			transactions, err := client.GetTransactions(context.Background(), conditions, metadata)
+			transactions, err := client.GetTransactions(context.Background(), conditions, metadata, &datastore.QueryParams{})
 			assert.NoError(t, err)
 			assert.IsType(t, []*bux.Transaction{}, transactions)
 			assert.Len(t, transactions, 2)
@@ -536,7 +537,6 @@ func TestSendToRecipients(t *testing.T) {
 
 // TestFinalizeTransaction will test the FinalizeTransaction method
 func TestFinalizeTransaction(t *testing.T) {
-
 	t.Run("finalize transaction", func(t *testing.T) {
 		httpclient := &http.Client{Transport: localRoundTripper{handler: http.NewServeMux()}}
 		client, err := New(
@@ -645,7 +645,7 @@ func TestAuthenticationWithOnlyAccessKey(t *testing.T) {
 			caseTitle: "GetTransactions",
 			path:      "/transaction/search",
 			clientMethod: func(c *BuxClient) (any, error) {
-				return c.GetTransactions(context.Background(), anyConditions, anyMetadataConditions)
+				return c.GetTransactions(context.Background(), anyConditions, anyMetadataConditions, &datastore.QueryParams{})
 			},
 		},
 	}
@@ -697,7 +697,6 @@ func TestAuthenticationWithOnlyAccessKey(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func assertAuthHeaders(t *testing.T, req *http.Request) {

--- a/transactions.go
+++ b/transactions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/BuxOrg/bux"
 	"github.com/BuxOrg/go-buxclient/transports"
+	"github.com/mrz1836/go-datastore"
 )
 
 // GetTransaction get a transaction by id
@@ -14,8 +15,9 @@ func (b *BuxClient) GetTransaction(ctx context.Context, txID string) (*bux.Trans
 
 // GetTransactions get all transactions matching search criteria
 func (b *BuxClient) GetTransactions(ctx context.Context, conditions map[string]interface{},
-	metadata *bux.Metadata) ([]*bux.Transaction, error) {
-	return b.transport.GetTransactions(ctx, conditions, metadata)
+	metadata *bux.Metadata, queryParams *datastore.QueryParams,
+) ([]*bux.Transaction, error) {
+	return b.transport.GetTransactions(ctx, conditions, metadata, queryParams)
 }
 
 // DraftToRecipients initialize a new P2PKH draft transaction to a list of recipients

--- a/transports/graphql.go
+++ b/transports/graphql.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libsv/go-bk/bec"
 	"github.com/libsv/go-bk/bip32"
 	"github.com/machinebox/graphql"
+	"github.com/mrz1836/go-datastore"
 )
 
 // graphQlService is the interface for GraphQL
@@ -609,8 +610,8 @@ func (g *TransportGraphQL) GetTransaction(ctx context.Context, txID string) (*bu
 
 // GetTransactions get a transactions, filtered by the given metadata
 func (g *TransportGraphQL) GetTransactions(ctx context.Context, conditions map[string]interface{},
-	metadataConditions *bux.Metadata) ([]*bux.Transaction, error) {
-
+	metadataConditions *bux.Metadata, queryParams *datastore.QueryParams,
+) ([]*bux.Transaction, error) {
 	querySignature := ""
 	queryArguments := ""
 

--- a/transports/http.go
+++ b/transports/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bitcoinschema/go-bitcoin/v2"
 	"github.com/libsv/go-bk/bec"
 	"github.com/libsv/go-bk/bip32"
+	"github.com/mrz1836/go-datastore"
 )
 
 // TransportHTTP is the struct for HTTP
@@ -354,11 +355,12 @@ func (h *TransportHTTP) GetTransaction(ctx context.Context, txID string) (*bux.T
 
 // GetTransactions will get a transactions by conditions
 func (h *TransportHTTP) GetTransactions(ctx context.Context, conditions map[string]interface{},
-	metadataConditions *bux.Metadata) ([]*bux.Transaction, error) {
-
+	metadataConditions *bux.Metadata, queryParams *datastore.QueryParams,
+) ([]*bux.Transaction, error) {
 	jsonStr, err := json.Marshal(map[string]interface{}{
-		FieldConditions: conditions,
-		FieldMetadata:   processMetadata(metadataConditions),
+		FieldConditions:  conditions,
+		FieldMetadata:    processMetadata(metadataConditions),
+		FieldQueryParams: queryParams,
 	})
 	if err != nil {
 		return nil, err

--- a/transports/interface.go
+++ b/transports/interface.go
@@ -41,7 +41,7 @@ type TransactionService interface {
 	DraftToRecipients(ctx context.Context, recipients []*Recipients, metadata *bux.Metadata) (*bux.DraftTransaction, error)
 	DraftTransaction(ctx context.Context, transactionConfig *bux.TransactionConfig, metadata *bux.Metadata) (*bux.DraftTransaction, error)
 	GetTransaction(ctx context.Context, txID string) (*bux.Transaction, error)
-	GetTransactions(ctx context.Context, conditions map[string]interface{}, metadataConditions *bux.Metadata) ([]*bux.Transaction, error)
+	GetTransactions(ctx context.Context, conditions map[string]interface{}, metadataConditions *bux.Metadata, queryParams *datastore.QueryParams) ([]*bux.Transaction, error)
 	RecordTransaction(ctx context.Context, hex, referenceID string, metadata *bux.Metadata) (*bux.Transaction, error)
 	UpdateTransactionMetadata(ctx context.Context, txID string, metadata *bux.Metadata) (*bux.Transaction, error)
 }

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -69,7 +69,5 @@ func processMetadata(metadata *bux.Metadata) *bux.Metadata {
 		metadata = &m
 	}
 
-	(*metadata)[FieldUserAgent] = BuxUserAgent
-
 	return metadata
 }


### PR DESCRIPTION
<!-- thank you for your contribution! ❤️  -->
Description:
-------

- Added query params to GetTransactions method which allow to paginate results
- Removed default UserAgent field from metadata. Before this change GetTransactions method returned only data with UserAgent in metadata, what caused getting only transaction made by bux with go-buxclient. Now it also returned incoming transactions from other sources
