### PR TITLE
fix(BUX-137): add unreserve utxos

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -78,3 +78,8 @@ func (b *BuxClient) SendToRecipients(ctx context.Context, recipients []*transpor
 
 	return b.RecordTransaction(ctx, hex, draft.ID, metadata)
 }
+
+// UnreserveUtxos unreserves utxos from draft transaction
+func (b *BuxClient) UnreserveUtxos(ctx context.Context, referenceID string) transports.ResponseError {
+	return b.transport.UnreserveUtxos(ctx, referenceID)
+}

--- a/transports/graphql.go
+++ b/transports/graphql.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	buxerrors "github.com/BuxOrg/bux-models/bux-errors"
 	"log"
 	"net/http"
+
+	buxerrors "github.com/BuxOrg/bux-models/bux-errors"
 
 	buxmodels "github.com/BuxOrg/bux-models"
 	"github.com/libsv/go-bk/bec"
@@ -836,6 +837,22 @@ func (g *TransportGraphQL) UpdateTransactionMetadata(ctx context.Context, txID s
 	}
 
 	return respData.Transaction, nil
+}
+
+// UnreserveUtxos will unreserve utxos from draft transaction
+func (g *TransportGraphQL) UnreserveUtxos(ctx context.Context, referenceID string) ResponseError {
+	reqBody := `
+	  mutation ($draft_id: String!) {
+        utxos_unreserve (
+		  draft_id: $draft_id
+        ) 
+      }`
+	variables := map[string]interface{}{
+		"draft_id": referenceID,
+	}
+
+	var respData bool
+	return g.doGraphQLQuery(ctx, reqBody, variables, &respData)
 }
 
 func (g *TransportGraphQL) doGraphQLQuery(ctx context.Context, reqBody string, variables map[string]interface{},

--- a/transports/interface.go
+++ b/transports/interface.go
@@ -2,6 +2,7 @@ package transports
 
 import (
 	"context"
+
 	buxmodels "github.com/BuxOrg/bux-models"
 	"github.com/libsv/go-bk/bip32"
 )
@@ -43,6 +44,7 @@ type TransactionService interface {
 	GetTransactionsCount(ctx context.Context, conditions map[string]interface{}, metadata *buxmodels.Metadata) (int64, ResponseError)
 	RecordTransaction(ctx context.Context, hex, referenceID string, metadata *buxmodels.Metadata) (*buxmodels.Transaction, ResponseError)
 	UpdateTransactionMetadata(ctx context.Context, txID string, metadata *buxmodels.Metadata) (*buxmodels.Transaction, ResponseError)
+	UnreserveUtxos(ctx context.Context, referenceID string) ResponseError
 }
 
 // PaymailService is the paymail related requests


### PR DESCRIPTION
Motivation:
Creation of a draft transaction will mark UTXOs as reserved, and those UTXOs can't be used for another transaction.

If a draft transaction was created, but the "record transaction" process failed, UTXOs will still be reserved and can't be used for another payment.

A mechanism for unreserving UTXOs should be added for such cases.